### PR TITLE
Fix pgsql_restore for working with dump from another owner

### DIFF
--- a/docker-compose-services/postgres/commands/postgres/pgsql_restore
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_restore
@@ -8,4 +8,4 @@
 su postgres -c "psql -U db -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO db; GRANT ALL ON SCHEMA public TO public;'"
 
 # Import via user postgres to avoid credentials prompt
-su postgres -c "pg_restore -U db db /mnt/ddev_config/import-db/postgresql.db.dump"
+su postgres -c "pg_restore --no-owner -U db -d db /mnt/ddev_config/import-db/postgresql.db.dump"


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:

`pg_restore` didn't work with dump from prod, as it used a different owner. Also complained about the arguments.

## How this PR Solves The Problem:

Added -d before the db name, and added --no-owner parameter.

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->
TBD 

## Related Issue Link(s):

